### PR TITLE
Something that I missed from the last PR

### DIFF
--- a/binaries/geph5-client/src/bin/geph5-client.rs
+++ b/binaries/geph5-client/src/bin/geph5-client.rs
@@ -11,7 +11,7 @@ struct CliArgs {
     #[arg(short, long)]
     config: PathBuf,
 
-    #[arg(short, long)]
+    #[arg(short, long, default_value_t = false)]
     /// don't start the client, but instead dump authentication info
     dry_run: bool,
 }


### PR DESCRIPTION
Just added a default value to the dry-run option of geph5-client, so that providing it in the cli when running isn't mandatory anymore.

Sorry for the back to back PRs, this should be it  :)