### PR TITLE
Add support for temporarily disabling ipv6

### DIFF
--- a/binaries/geph5-client/src/ipv6.rs
+++ b/binaries/geph5-client/src/ipv6.rs
@@ -1,0 +1,19 @@
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::*;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use windows::*;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::*;
+
+#[cfg(target_os = "android")]
+mod dummy;
+#[cfg(target_os = "android")]
+pub use dummy::*;

--- a/binaries/geph5-client/src/ipv6/dummy.rs
+++ b/binaries/geph5-client/src/ipv6/dummy.rs
@@ -1,0 +1,13 @@
+use anyhow::Context;
+
+// Try to disable IPv6 globally on Windows machines.
+pub fn disable_ipv6() -> anyhow::Result<()> {
+    // TODO
+    Ok(())
+}
+
+// Try to disable IPv6 globally on Windows machines.
+pub fn enable_ipv6() -> anyhow::Result<()> {
+    // TODO
+    Ok(())
+}

--- a/binaries/geph5-client/src/ipv6/linux.rs
+++ b/binaries/geph5-client/src/ipv6/linux.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+use anyhow::Context;
+
+// Try to disable IPv6 globally on Linux machines.
+// This would need root privilages to work and will fail otherwise.
+pub fn disable_ipv6() -> anyhow::Result<()> {
+    Command::new("sh")
+        .args([
+            "-c",
+            "echo 1 | tee /proc/sys/net/ipv6/conf/all/disable_ipv6",
+        ])
+        .output()
+        .context("Failed to disable IPv6 globally")?;
+    Ok(())
+}
+
+// Try to disable IPv6 globally on Linux machines.
+// This would need root privilages to work and will fail otherwise.
+pub fn enable_ipv6() -> anyhow::Result<()> {
+    Command::new("sh")
+        .args([
+            "-c",
+            "echo 0 | tee /proc/sys/net/ipv6/conf/all/disable_ipv6",
+        ])
+        .output()
+        .context("Failed to enable IPv6 globally")?;
+    Ok(())
+}

--- a/binaries/geph5-client/src/ipv6/macos.rs
+++ b/binaries/geph5-client/src/ipv6/macos.rs
@@ -1,0 +1,13 @@
+use anyhow::Context;
+
+// Try to disable IPv6 globally on Windows machines.
+pub fn disable_ipv6() -> anyhow::Result<()> {
+    // TODO
+    Ok(())
+}
+
+// Try to disable IPv6 globally on Windows machines.
+pub fn enable_ipv6() -> anyhow::Result<()> {
+    // TODO
+    Ok(())
+}

--- a/binaries/geph5-client/src/ipv6/windows.rs
+++ b/binaries/geph5-client/src/ipv6/windows.rs
@@ -1,0 +1,13 @@
+use anyhow::Context;
+
+// Try to disable IPv6 globally on Windows machines.
+pub fn disable_ipv6() -> anyhow::Result<()> {
+    // TODO
+    Ok(())
+}
+
+// Try to disable IPv6 globally on Windows machines.
+pub fn enable_ipv6() -> anyhow::Result<()> {
+    // TODO
+    Ok(())
+}

--- a/binaries/geph5-client/src/lib.rs
+++ b/binaries/geph5-client/src/lib.rs
@@ -13,6 +13,7 @@ mod client_inner;
 mod control_prot;
 mod database;
 mod http_proxy;
+mod ipv6;
 pub mod logs;
 mod route;
 mod socks5;


### PR DESCRIPTION
If your device is assigned an IPv6 address, Geph5 doesn't seem like it can successfully disable IPv6 (at least on my Linux machine), which leads to issues that may completely stop you from being able to use it as a VPN

This is a WIP PR. Any additional info (which I'm pretty sure I'm missing) and opinion is appreciated. 