### PR TITLE
Add README docs for client, broker and exit

### DIFF
--- a/binaries/geph5-broker/README.md
+++ b/binaries/geph5-broker/README.md
@@ -1,0 +1,21 @@
+# geph5-broker
+
+`geph5-broker` is the central coordination service.  Clients contact the broker to authenticate, obtain connect tokens and receive a list of available exits.  Bridges and exits also register themselves here.  The broker exposes a JSON‑RPC API over HTTP and a raw TCP protocol for bridge/exit communication.
+
+Configuration is provided via YAML as parsed by `ConfigFile` in `src/main.rs`.  Paths to cryptographic keys, database connection information and listener addresses are specified here.
+
+Example configuration:
+
+```yaml
+listen: 0.0.0.0:9000
+tcp_listen: 0.0.0.0:9001
+master_secret: /etc/geph5/broker/master.bin
+mizaru_keys: /etc/geph5/broker/mizaru
+postgres_url: postgres://geph:password@localhost/geph
+bridge_token: bridge_secret
+exit_token: exit_secret
+puzzle_difficulty: 24
+openai_key: your-openai-key
+payment_url: https://web-backend.geph.io/rpc
+payment_support_secret: support-secret
+```

--- a/binaries/geph5-client/README.md
+++ b/binaries/geph5-client/README.md
@@ -1,0 +1,30 @@
+# geph5-client
+
+`geph5-client` is the main user facing daemon. It establishes and maintains a session with the broker and chosen exits, then exposes local proxy endpoints (SOCKS5/HTTP) to tunnel user traffic through the Geph network.  The binary can optionally operate in VPN mode by tunnelling packets directly.  It also exposes a control RPC interface used by GUI front‑ends.
+
+The client is configured with a YAML file matching the `Config` struct in `src/client.rs`.  Most fields are optional and control which services listen locally, how to reach the broker, and optional VPN or bridge settings.
+
+Example configuration:
+
+```yaml
+socks5_listen: 127.0.0.1:9910
+http_proxy_listen: 127.0.0.1:9911
+pac_listen: 127.0.0.1:9912
+control_listen: 127.0.0.1:9913
+exit_constraint: auto
+bridge_mode: auto
+cache: /var/cache/geph5-client
+broker:
+  direct: "https://broker.geph.io/"
+broker_keys:
+  master: "deadbeef..."
+  mizaru_free: "deadbeef..."
+  mizaru_plus: "deadbeef..."
+vpn: false
+spoof_dns: false
+passthrough_china: false
+credentials:
+  legacy_username_password:
+    username: "user"
+    password: "pass"
+```

--- a/binaries/geph5-exit/README.md
+++ b/binaries/geph5-exit/README.md
@@ -1,0 +1,29 @@
+# geph5-exit
+
+`geph5-exit` is the server component that terminates client tunnels and forwards traffic to the open Internet.  Exits register with the broker so that clients can discover them.  Each exit enforces rate limits and may restrict access based on account level or country.
+
+Configuration is supplied in YAML following the `ConfigFile` struct in `src/main.rs`.  The file specifies keys used to sign descriptors, how the exit connects to the broker and networking details such as listening addresses and country information.
+
+Example configuration:
+
+```yaml
+signing_secret: /etc/geph5/exit/signing.key
+broker:
+  url: https://broker.geph.io/
+  auth_token: my-secret
+c2e_listen: 0.0.0.0:9002
+b2e_listen: 0.0.0.0:9003
+ip_addr: 203.0.113.5
+country: USA
+city: NYC
+metadata:
+  allowed_levels: [plus]
+  category: [core]
+country_blacklist: []
+free_ratelimit: 300
+plus_ratelimit: 30000
+total_ratelimit: 125000
+free_port_whitelist: [80,443,8080,8443,22,53]
+task_limit: 1000000
+ipv6_subnet: "2001:db8::/64"
+```


### PR DESCRIPTION
## Summary
- document geph5-client configuration usage
- add geph5-broker intro and config example
- describe geph5-exit purpose and YAML format

## Testing
- `cargo test --workspace --all-targets --no-run` *(fails: build interrupted because compile takes too long)*