### PR TITLE
Increase sosistab3 handshake time window

### DIFF
--- a/libraries/sillad-sosistab3/src/listener.rs
+++ b/libraries/sillad-sosistab3/src/listener.rs
@@ -38,7 +38,7 @@ async fn listen_loop<P: Pipe>(
     send_pipe: Sender<SosistabPipe<P>>,
     cookie: Cookie,
 ) -> std::io::Result<()> {
-    const WAIT_INTERVAL: Duration = Duration::from_secs(30);
+    const WAIT_INTERVAL: Duration = Duration::from_secs(300);
 
     if std::env::var("SOSISTAB3_WAIT").is_ok() {
         async_io::Timer::after(WAIT_INTERVAL).await;


### PR DESCRIPTION
## Summary
- relax server handshake timing check from 30 seconds to 5 minutes

## Testing
- `cargo test --workspace --locked` *(fails: could not compile `geph5-client`)*