### PR TITLE
Remove anyhow from mizaru2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,7 +4911,6 @@ dependencies = [
 name = "mizaru2"
 version = "0.2.13"
 dependencies = [
- "anyhow",
  "blake3",
  "blind-rsa-signatures",
  "hex",
@@ -4919,6 +4918,7 @@ dependencies = [
  "rayon",
  "serde",
  "stdcode",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/libraries/mizaru2/Cargo.toml
+++ b/libraries/mizaru2/Cargo.toml
@@ -12,6 +12,6 @@ blind-rsa-signatures = "0.15.1"
 rand = "0.8.5"
 stdcode = "0.1.14"
 serde = { version = "1.0.204", features = ["derive", "rc"] }
-anyhow = "1.0.86"
+thiserror = "1.0.61"
 rayon = "1.10.0"
 hex = "0.4.3"


### PR DESCRIPTION
## Summary
- drop `anyhow` from `mizaru2`
- implement a small `Error` enum with `thiserror`
- update crate users to return `Result<T, Error>`

## Testing
- `cargo check -p mizaru2`
- `cargo check -p geph5-broker-protocol`
- `cargo check -p geph5-exit`
- `cargo test -p mizaru2` *(fails: long-running tests blocked)*