### PR TITLE
Add client bandwidth accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "aws-sdk-lambda",
  "aws-smithy-runtime",
  "base32 0.5.1",
+ "base64 0.22.1",
  "blake3",
  "blind-rsa-signatures",
  "bytes",

--- a/binaries/geph5-client/Cargo.toml
+++ b/binaries/geph5-client/Cargo.toml
@@ -33,6 +33,7 @@ aws-config = { version = "=1.5.4", optional = true }
 aws-sdk-lambda = { version = "=1.35.0", features = ["rustls"], optional = true }
 aws-smithy-runtime = { version = "1", optional = true }
 base32 = "0.5.1"
+base64 = "0.22.1"
 blake3 = "1.5.1"
 blind-rsa-signatures = "0.15.1"
 bytes = "1.6.0"

--- a/binaries/geph5-client/src/bw_accounting.rs
+++ b/binaries/geph5-client/src/bw_accounting.rs
@@ -1,0 +1,77 @@
+use std::{
+    sync::{atomic::{AtomicUsize, Ordering}, Arc},
+    time::Duration,
+};
+
+use async_event::Event;
+use base64::{prelude::BASE64_STANDARD_NO_PAD, Engine};
+use futures_concurrency::future::Race;
+use futures_util::{AsyncReadExt, AsyncWriteExt};
+
+use crate::{bw_token::bw_token_consume, Config};
+use anyctx::AnyCtx;
+
+const THRESHOLD: usize = 5 * 1024 * 1024;
+
+/// Handles the exit-to-client bandwidth accounting protocol.
+#[tracing::instrument(skip_all)]
+pub async fn bw_accounting_client_loop(
+    ctx: AnyCtx<Config>,
+    stream: picomux::Stream,
+) -> anyhow::Result<()> {
+    let (mut read, mut write) = stream.split();
+    let bytes_left = Arc::new(AtomicUsize::new(usize::MAX));
+    let change_event = Arc::new(Event::new());
+
+    let read_fut = {
+        let bytes_left = bytes_left.clone();
+        let change_event = change_event.clone();
+        async move {
+            let mut buf = [0u8; 8];
+            loop {
+                read.read_exact(&mut buf).await?;
+                let val = u64::from_be_bytes(buf) as usize;
+                bytes_left.store(val, Ordering::SeqCst);
+                change_event.notify_one();
+            }
+            #[allow(unreachable_code)]
+            Ok::<(), anyhow::Error>(())
+        }
+    };
+
+    let write_fut = {
+        let change_event = change_event.clone();
+        let bytes_left = bytes_left.clone();
+        let ctx = ctx.clone();
+        async move {
+            loop {
+                change_event
+                    .wait_until(|| {
+                        let left = bytes_left.load(Ordering::SeqCst);
+                        if left < THRESHOLD {
+                            Some(left)
+                        } else {
+                            None
+                        }
+                    })
+                    .await;
+                while bytes_left.load(Ordering::SeqCst) < THRESHOLD {
+                    if let Some((token, sig)) = bw_token_consume(&ctx).await? {
+                        let enc = BASE64_STANDARD_NO_PAD
+                            .encode(&(token, sig).stdcode());
+                        write.write_all(enc.as_bytes()).await?;
+                        write.write_all(b"\n").await?;
+                    } else {
+                        smol::Timer::after(Duration::from_secs(1)).await;
+                    }
+                    change_event.listen().await;
+                }
+            }
+            #[allow(unreachable_code)]
+            Ok::<(), anyhow::Error>(())
+        }
+    };
+
+    (read_fut, write_fut).race().await
+}
+

--- a/binaries/geph5-client/src/bw_accounting.rs
+++ b/binaries/geph5-client/src/bw_accounting.rs
@@ -23,6 +23,7 @@ pub async fn bw_accounting_client_loop(
     ctx: AnyCtx<Config>,
     stream: picomux::Stream,
 ) -> anyhow::Result<()> {
+    tracing::info!("BW ACCOUNT START!");
     let (mut read, mut write) = stream.split();
     let bytes_left = Arc::new(AtomicUsize::new(usize::MAX));
     let change_event = Arc::new(Event::new());
@@ -34,8 +35,9 @@ pub async fn bw_accounting_client_loop(
             let mut buf = [0u8; 8];
             loop {
                 read.read_exact(&mut buf).await?;
-                let val = u64::from_be_bytes(buf) as usize;
-                bytes_left.store(val, Ordering::SeqCst);
+                let bytes = u64::from_be_bytes(buf) as usize;
+                tracing::debug!(bytes, "obtained remote bw");
+                bytes_left.store(bytes, Ordering::SeqCst);
                 change_event.notify_one();
             }
             #[allow(unreachable_code)]

--- a/binaries/geph5-client/src/bw_accounting.rs
+++ b/binaries/geph5-client/src/bw_accounting.rs
@@ -15,7 +15,7 @@ use stdcode::StdcodeSerializeExt;
 use crate::{bw_token::bw_token_consume, Config};
 use anyctx::AnyCtx;
 
-const THRESHOLD: usize = 5 * 1024 * 1024;
+const THRESHOLD: usize = 5_000_000;
 
 /// Handles the exit-to-client bandwidth accounting protocol.
 #[tracing::instrument(skip_all)]
@@ -40,8 +40,6 @@ pub async fn bw_accounting_client_loop(
                 bytes_left.store(bytes, Ordering::SeqCst);
                 change_event.notify_one();
             }
-            #[allow(unreachable_code)]
-            Ok::<(), anyhow::Error>(())
         }
     };
 
@@ -70,8 +68,6 @@ pub async fn bw_accounting_client_loop(
                     smol::Timer::after(Duration::from_secs(1)).await;
                 }
             }
-            #[allow(unreachable_code)]
-            Ok::<(), anyhow::Error>(())
         }
     };
 

--- a/binaries/geph5-client/src/client_inner.rs
+++ b/binaries/geph5-client/src/client_inner.rs
@@ -222,13 +222,13 @@ async fn proxy_loop(
     // we first register the session metadata
     mux.open(&serde_json::to_vec(&ctx.init().sess_metadata)?).await?;
 
-    // start bandwidth accounting loop
-    if let Ok(stream) = mux.open(b"!bw-accounting").await {
-        smolscale::spawn(bw_accounting_client_loop(ctx.clone(), stream)).detach();
-    }
+
 
     async {
         nursery!({
+            // start bandwidth accounting loop
+            spawn!(bw_accounting_client_loop(ctx.clone(), mux.open(b"!bw-accounting").await?)).detach();
+
             loop {
                 let mux = mux.clone();
                 let ctx = ctx.clone();

--- a/binaries/geph5-client/src/client_inner.rs
+++ b/binaries/geph5-client/src/client_inner.rs
@@ -222,8 +222,6 @@ async fn proxy_loop(
     // we first register the session metadata
     mux.open(&serde_json::to_vec(&ctx.init().sess_metadata)?).await?;
 
-
-
     async {
         nursery!({
             // start bandwidth accounting loop

--- a/binaries/geph5-client/src/client_inner.rs
+++ b/binaries/geph5-client/src/client_inner.rs
@@ -224,8 +224,6 @@ async fn proxy_loop(
 
     async {
         nursery!({
-            // start bandwidth accounting loop
-            spawn!(bw_accounting_client_loop(ctx.clone(), mux.open(b"!bw-accounting").await?)).detach();
 
             loop {
                 let mux = mux.clone();
@@ -253,6 +251,7 @@ async fn proxy_loop(
             }
         })
     }.or(mux.wait_until_dead())
+    .or(bw_accounting_client_loop(ctx.clone(), mux.open(b"!bw-accounting").await?))
     .await
 }
 

--- a/binaries/geph5-client/src/client_inner.rs
+++ b/binaries/geph5-client/src/client_inner.rs
@@ -251,7 +251,13 @@ async fn proxy_loop(
             }
         })
     }.or(mux.wait_until_dead())
-    .or(bw_accounting_client_loop(ctx.clone(), mux.open(b"!bw-accounting").await?))
+    .or(async {
+        if instance == 0 {
+            bw_accounting_client_loop(ctx.clone(), mux.open(b"!bw-accounting").await?).await
+        } else {
+            smol::future::pending().await
+        }
+    })
     .await
 }
 

--- a/binaries/geph5-client/src/lib.rs
+++ b/binaries/geph5-client/src/lib.rs
@@ -17,6 +17,7 @@ use once_cell::sync::OnceCell;
 mod auth;
 mod broker;
 mod bw_token;
+mod bw_accounting;
 mod china;
 mod client;
 mod client_inner;

--- a/binaries/geph5-exit/src/bw_accounting.rs
+++ b/binaries/geph5-exit/src/bw_accounting.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     sync::{
-        atomic::AtomicUsize,
+        atomic::{AtomicU64, AtomicUsize},
         Arc,
     },
     time::Duration,
@@ -16,6 +16,7 @@ use mizaru2::{ClientToken, SingleUnblindedSignature};
 /// Process the client-to-exit bandwidth accounting protocol.
 #[tracing::instrument]
 pub async fn bw_accounting_loop(account: BwAccount, stream: picomux::Stream) -> anyhow::Result<()> {
+    tracing::debug!("starting accounting loop!");
     let (read, mut write) = stream.split();
     let mut read = BufReader::new(read);
     let read_fut = async {
@@ -36,13 +37,14 @@ pub async fn bw_accounting_loop(account: BwAccount, stream: picomux::Stream) -> 
                 .change_event
                 .wait_until(|| {
                     let bytes_left = account.bytes_left();
-                    if bytes_left == last_bytes_left {
+                    if bytes_left != last_bytes_left {
                         Some(bytes_left)
                     } else {
                         None
                     }
                 })
                 .await;
+            tracing::debug!(bytes_left, "bytes left lol");
             last_bytes_left = bytes_left;
             write.write_all(&(bytes_left as u64).to_be_bytes()).await?;
             // debounce
@@ -52,10 +54,10 @@ pub async fn bw_accounting_loop(account: BwAccount, stream: picomux::Stream) -> 
     (read_fut, write_fut).race().await
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct BwAccount {
     id: u64,
-    bytes_left: Option<Arc<AtomicUsize>>,
+    bytes_left: Arc<AtomicU64>,
     change_event: Arc<Event>,
 }
 
@@ -65,7 +67,18 @@ impl Debug for BwAccount {
     }
 }
 
+static BW_ACCOUNT: AtomicU64 = AtomicU64::new(0);
+
 impl BwAccount {
+    /// Create an unlimited BwAccount
+    pub fn unlimited() -> Self {
+        Self {
+            id: BW_ACCOUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            bytes_left: Default::default(),
+            change_event: Default::default(),
+        }
+    }
+
     /// Process a bandwidth token, crediting bandwidth as needed.
     pub async fn credit_bw(
         &self,
@@ -74,32 +87,29 @@ impl BwAccount {
     ) -> anyhow::Result<()> {
         // TODO actually ask the broker
         smol::Timer::after(Duration::from_secs(2)).await;
-        if let Some(bytes_left) = &self.bytes_left {
-            bytes_left.fetch_add(10_000_000, std::sync::atomic::Ordering::SeqCst);
-            self.change_event.notify_one();
-        }
+        self.bytes_left
+            .fetch_add(10_000_000, std::sync::atomic::Ordering::SeqCst);
+        self.change_event.notify_one();
+
         Ok(())
     }
 
     /// Consumes bandwidth, returning the remaining bandwidth
-    pub fn consume_bw(&self, bytes: usize) -> usize {
-        if let Some(bytes_left) = &self.bytes_left {
-            let res = bytes_left
-                .fetch_update(
-                    std::sync::atomic::Ordering::SeqCst,
-                    std::sync::atomic::Ordering::SeqCst,
-                    |x| Some(x.saturating_sub(bytes)),
-                )
-                .unwrap();
-            self.change_event.notify_one();
-            res
-        } else {
-            usize::MAX
-        }
+    pub fn consume_bw(&self, bytes: usize) -> u64 {
+        let res = self
+            .bytes_left
+            .fetch_update(
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+                |x| Some(x.saturating_sub(bytes as _)),
+            )
+            .unwrap();
+        self.change_event.notify_one();
+        res
     }
 
     /// Gets the current remaining bandwidth.
-    pub fn bytes_left(&self) -> usize {
-        self.consume_bw(0)
+    pub fn bytes_left(&self) -> u64 {
+        self.bytes_left.load(std::sync::atomic::Ordering::SeqCst)
     }
 }

--- a/binaries/geph5-exit/src/listen.rs
+++ b/binaries/geph5-exit/src/listen.rs
@@ -152,7 +152,7 @@ async fn handle_client(mut client: impl Pipe) -> anyhow::Result<()> {
     let mut is_free = false;
 
     // TODO initialize this properly
-    let bw_account = BwAccount::default();
+    let bw_account = BwAccount::unlimited();
     let ratelimit = if CONFIG_FILE.wait().broker.is_some() {
         let (level, token, sig): (AccountLevel, ClientToken, UnblindedSignature) =
             stdcode::deserialize(&client_hello.credentials)
@@ -164,9 +164,9 @@ async fn handle_client(mut client: impl Pipe) -> anyhow::Result<()> {
             tracing::warn!(err = debug(e), "**** BAD BAD bad token received ***")
         })?;
         is_free = level == AccountLevel::Free;
-        get_ratelimiter(level, token).await
+        get_ratelimiter(bw_account.clone(), level, token).await
     } else {
-        RateLimiter::unlimited(BwAccount::default(), None)
+        RateLimiter::unlimited(bw_account.clone(), None)
     };
 
     let exit_hello = ExitHello {

--- a/binaries/geph5-exit/src/ratelimit.rs
+++ b/binaries/geph5-exit/src/ratelimit.rs
@@ -80,17 +80,16 @@ pub fn update_load_loop() {
     }
 }
 
-pub async fn get_ratelimiter(level: AccountLevel, token: ClientToken) -> RateLimiter {
+pub async fn get_ratelimiter(
+    bw_account: BwAccount,
+    level: AccountLevel,
+    token: ClientToken,
+) -> RateLimiter {
     match level {
         AccountLevel::Free => {
             FREE_RL_CACHE
                 .get_with(blake3::hash(&(level, token).stdcode()), async {
-                    RateLimiter::new(
-                        CONFIG_FILE.wait().free_ratelimit,
-                        100,
-                        BwAccount::default(),
-                        None,
-                    )
+                    RateLimiter::new(CONFIG_FILE.wait().free_ratelimit, 100, bw_account, None)
                 })
                 .await
         }
@@ -100,7 +99,7 @@ pub async fn get_ratelimiter(level: AccountLevel, token: ClientToken) -> RateLim
                     RateLimiter::new(
                         CONFIG_FILE.wait().plus_ratelimit,
                         100,
-                        BwAccount::default(),
+                        bw_account,
                         Some(token.to_string()),
                     )
                 })

--- a/binaries/geph5-exit/src/ratelimit.rs
+++ b/binaries/geph5-exit/src/ratelimit.rs
@@ -80,16 +80,17 @@ pub fn update_load_loop() {
     }
 }
 
-pub async fn get_ratelimiter(
-    bw_account: BwAccount,
-    level: AccountLevel,
-    token: ClientToken,
-) -> RateLimiter {
+pub async fn get_ratelimiter(level: AccountLevel, token: ClientToken) -> RateLimiter {
     match level {
         AccountLevel::Free => {
             FREE_RL_CACHE
                 .get_with(blake3::hash(&(level, token).stdcode()), async {
-                    RateLimiter::new(CONFIG_FILE.wait().free_ratelimit, 100, bw_account, None)
+                    RateLimiter::new(
+                        CONFIG_FILE.wait().free_ratelimit,
+                        100,
+                        BwAccount::unlimited(),
+                        None,
+                    )
                 })
                 .await
         }
@@ -99,7 +100,7 @@ pub async fn get_ratelimiter(
                     RateLimiter::new(
                         CONFIG_FILE.wait().plus_ratelimit,
                         100,
-                        bw_account,
+                        BwAccount::empty(),
                         Some(token.to_string()),
                     )
                 })
@@ -134,6 +135,11 @@ impl RateLimiter {
         }
     }
 
+    /// Gets the BwAccount out of this ratelimit
+    pub fn bw_account(&self) -> BwAccount {
+        self.bw_account.clone()
+    }
+
     /// Creates a new unlimited ratelimit.
     pub fn unlimited(bw_account: BwAccount, log_tag: Option<String>) -> Self {
         Self {
@@ -151,6 +157,9 @@ impl RateLimiter {
             }
         }
 
+        // TODO do something when the bandwidth is exhausted
+        self.bw_account.consume_bw(bytes as usize);
+
         TOTAL_BYTE_COUNT.fetch_add(bytes as _, Ordering::Relaxed);
         if bytes == 0 {
             return;
@@ -158,6 +167,7 @@ impl RateLimiter {
         let multiplier = (1.0 / (1.0 - get_load().min(0.999)) - 1.0) / 2.0;
 
         let bytes = (bytes as f32 * (multiplier.max(1.0))).min(100000.0);
+
         if let Some(inner) = &self.inner {
             let mut delay: f32 = 0.005;
 
@@ -165,7 +175,6 @@ impl RateLimiter {
                 .check_n((bytes as u32).try_into().unwrap())
                 .unwrap()
                 .is_err()
-                || self.bw_account.consume_bw(bytes as usize) == 0
             {
                 smol::Timer::after(Duration::from_secs_f32(delay)).await;
                 delay += rand::random::<f32>() * 0.05;


### PR DESCRIPTION
## Summary
- consume bandwidth tokens in the client database
- implement client-side bandwidth accounting loop
- start accounting loop for every PicoMux session

## Testing
- `cargo check -q --package geph5-client`

------
https://chatgpt.com/codex/tasks/task_b_683a1638e81c8333ad89ea75569be5ea