### PR TITLE
Do not unset proxy unless PROXY_AUTOCONF is on

### DIFF
--- a/binaries/geph5-client-gui/src/tabs/dashboard.rs
+++ b/binaries/geph5-client-gui/src/tabs/dashboard.rs
@@ -100,7 +100,9 @@ impl Dashboard {
             } else if ui.button(l10n("disconnect")).clicked() {
                 tracing::warn!("disconnect clicked");
                 DAEMON_HANDLE.stop()?;
-                unset_http_proxy()?;
+                if PROXY_AUTOCONF.get() {
+                    unset_http_proxy()?;
+                }
             }
             anyhow::Ok(())
         })


### PR DESCRIPTION
So that if auto configure proxy is OFF, the sudo dialog won't pop up when user click disconnect 