### PR TITLE
Add hex obfuscation protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ dependencies = [
  "serde_yaml",
  "sillad",
  "sillad-conntest",
+ "sillad-hex",
  "sillad-native-tls",
  "sillad-sosistab3",
  "simple-dns 0.7.1",
@@ -3544,6 +3545,7 @@ dependencies = [
  "serde_yaml",
  "sillad",
  "sillad-conntest",
+ "sillad-hex",
  "sillad-native-tls",
  "sillad-sosistab3",
  "simple-dns 0.9.3",
@@ -3636,6 +3638,7 @@ dependencies = [
  "serde_json",
  "sillad",
  "sillad-conntest",
+ "sillad-hex",
  "sillad-native-tls",
  "sillad-sosistab3",
  "smol 2.0.2",
@@ -7120,6 +7123,17 @@ dependencies = [
  "smolscale",
  "tachyonix",
  "tracing",
+]
+
+[[package]]
+name = "sillad-hex"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "hex",
+ "pin-project",
+ "sillad",
 ]
 
 [[package]]

--- a/binaries/geph5-broker/src/routes.rs
+++ b/binaries/geph5-broker/src/routes.rs
@@ -167,6 +167,9 @@ fn protocol_to_descriptor(protocol: ObfsProtocol, addr: SocketAddr) -> RouteDesc
             sni_domain: Some("labooyah-squish.be".into()),
             lower: protocol_to_descriptor(*obfs_protocol, addr).into(),
         },
+        ObfsProtocol::Hex(obfs_protocol) => RouteDescriptor::Hex {
+            lower: protocol_to_descriptor(*obfs_protocol, addr).into(),
+        },
         ObfsProtocol::Sosistab3New(cookie, obfs_protocol) => RouteDescriptor::Sosistab3 {
             cookie,
             lower: protocol_to_descriptor(*obfs_protocol, addr).into(),

--- a/binaries/geph5-client/Cargo.toml
+++ b/binaries/geph5-client/Cargo.toml
@@ -88,6 +88,7 @@ sillad = { version= "0.2.6", path = "../../libraries/sillad" }
 sillad-conntest = { version = "0.2", path = "../../libraries/sillad-conntest" }
 sillad-native-tls = {version="0.2", path="../../libraries/sillad-native-tls"}
 sillad-sosistab3 = { version = "0.2.7", path = "../../libraries/sillad-sosistab3" }
+sillad-hex = { path = "../../libraries/sillad-hex" }
 simple-dns = "0.7.0"
 slab = "0.4.9"
 smol = "2.0.0"

--- a/binaries/geph5-client/src/get_dialer.rs
+++ b/binaries/geph5-client/src/get_dialer.rs
@@ -21,6 +21,7 @@ use sillad::{
 };
 use sillad_conntest::ConnTestDialer;
 use sillad_sosistab3::{dialer::SosistabDialer, Cookie};
+use sillad_hex::HexDialer;
 
 use smol_timeout2::TimeoutExt as _;
 
@@ -296,6 +297,10 @@ fn route_to_dialer(ctx: &AnyCtx<Config>, route: &RouteDescriptor) -> DynDialer {
                 ping_count: *ping_count as _,
             }
             .dynamic()
+        }
+        RouteDescriptor::Hex { lower } => {
+            let lower = route_to_dialer(ctx, lower);
+            HexDialer { inner: lower }.dynamic()
         }
 
         RouteDescriptor::Other(_) => FailingDialer.dynamic(),

--- a/binaries/geph5-exit/Cargo.toml
+++ b/binaries/geph5-exit/Cargo.toml
@@ -11,6 +11,7 @@ sillad = { path = "../../libraries/sillad" }
 sillad-sosistab3 = { path = "../../libraries/sillad-sosistab3" }
 sillad-conntest = { path = "../../libraries/sillad-conntest" }
 sillad-native-tls = { path = "../../libraries/sillad-native-tls" }
+sillad-hex = { path = "../../libraries/sillad-hex" }
 picomux = { path = "../../libraries/picomux" }
 async-trait = "0.1.80"
 nanorpc = "0.1.12"

--- a/binaries/geph5-exit/src/listen/b2e_process.rs
+++ b/binaries/geph5-exit/src/listen/b2e_process.rs
@@ -6,6 +6,7 @@ use geph5_misc_rpc::bridge::{B2eMetadata, ObfsProtocol};
 use sillad::listener::{DynListener, ListenerExt};
 use sillad_conntest::ConnTestListener;
 use sillad_sosistab3::{listener::SosistabListener, Cookie};
+use sillad_hex::HexListener;
 use tachyonix::Receiver;
 
 use super::{handle_client, tls::dummy_tls_config};
@@ -30,6 +31,10 @@ fn create_listener(protocol: ObfsProtocol, bottom: ReceiverListener) -> DynListe
             ConnTestListener::new(inner).dynamic()
         }
         ObfsProtocol::None => bottom.dynamic(),
+        ObfsProtocol::Hex(obfs_protocol) => {
+            let inner = create_listener(*obfs_protocol, bottom);
+            HexListener { inner }.dynamic()
+        }
         ObfsProtocol::PlainTls(obfs_protocol) => {
             let inner = create_listener(*obfs_protocol, bottom);
             sillad_native_tls::TlsListener::new(inner, dummy_tls_config()).dynamic()

--- a/binaries/geph5-prototest/Cargo.toml
+++ b/binaries/geph5-prototest/Cargo.toml
@@ -35,6 +35,7 @@ sillad = { path = "../../libraries/sillad" }
 sillad-conntest = { path = "../../libraries/sillad-conntest" }
 sillad-native-tls = { path = "../../libraries/sillad-native-tls" }
 sillad-sosistab3 = { path = "../../libraries/sillad-sosistab3" }
+sillad-hex = { path = "../../libraries/sillad-hex" }
 smol = "2.0.0"
 smol-timeout2 = "0.6.1"
 smolscale = "0.4.15"

--- a/binaries/geph5-prototest/src/stack.rs
+++ b/binaries/geph5-prototest/src/stack.rs
@@ -17,6 +17,8 @@ pub fn parse_stack(spec: &str) -> anyhow::Result<ObfsProtocol> {
             proto = ObfsProtocol::PlainTls(Box::new(proto));
         } else if part.eq_ignore_ascii_case("conntest") {
             proto = ObfsProtocol::ConnTest(Box::new(proto));
+        } else if part.eq_ignore_ascii_case("hex") {
+            proto = ObfsProtocol::Hex(Box::new(proto));
         } else if part.eq_ignore_ascii_case("none") {
             // explicitly no-op
         } else {
@@ -30,6 +32,7 @@ use sillad::{listener::{DynListener, Listener, ListenerExt}, dialer::{DynDialer,
 use sillad_conntest::{ConnTestListener, ConnTestDialer};
 use sillad_sosistab3::{listener::SosistabListener, dialer::SosistabDialer, Cookie};
 use sillad_native_tls::{TlsListener, TlsDialer};
+use sillad_hex::{HexDialer, HexListener};
 use async_native_tls::{TlsConnector, TlsAcceptor};
 use time::OffsetDateTime;
 use time::Duration as TimeDuration;
@@ -51,6 +54,10 @@ where
         ObfsProtocol::PlainTls(inner) => {
             let inner = listener_from_stack(*inner, bottom, tls_acceptor);
             TlsListener::new(inner, tls_acceptor.clone()).dynamic()
+        }
+        ObfsProtocol::Hex(inner) => {
+            let inner = listener_from_stack(*inner, bottom, tls_acceptor);
+            HexListener { inner }.dynamic()
         }
         ObfsProtocol::Sosistab3New(cookie, inner) => {
             let inner = listener_from_stack(*inner, bottom, tls_acceptor);
@@ -80,6 +87,10 @@ pub fn dialer_from_stack(proto: &ObfsProtocol, addr: std::net::SocketAddr) -> Dy
                     .min_protocol_version(None)
                     .max_protocol_version(None);
                 TlsDialer::new(lower, connector, "example.com".into()).dynamic()
+            }
+            ObfsProtocol::Hex(sub) => {
+                let lower = inner(&*sub, lower);
+                HexDialer { inner: lower }.dynamic()
             }
             ObfsProtocol::Sosistab3New(cookie, sub) => {
                 let lower = inner(&*sub, lower);

--- a/libraries/geph5-broker-protocol/src/route.rs
+++ b/libraries/geph5-broker-protocol/src/route.rs
@@ -29,6 +29,9 @@ pub enum RouteDescriptor {
         ping_count: u32,
         lower: Box<RouteDescriptor>,
     },
+    Hex {
+        lower: Box<RouteDescriptor>,
+    },
 
     #[serde(untagged)]
     Other(serde_json::Value),

--- a/libraries/geph5-misc-rpc/src/bridge.rs
+++ b/libraries/geph5-misc-rpc/src/bridge.rs
@@ -18,6 +18,7 @@ pub enum ObfsProtocol {
     None,
     ConnTest(Box<Self>),
     PlainTls(Box<Self>),
+    Hex(Box<Self>),
     Sosistab3New(String, Box<Self>),
 }
 

--- a/libraries/sillad-hex/Cargo.toml
+++ b/libraries/sillad-hex/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sillad-hex"
+edition = "2021"
+version = "0.1.0"
+description = "A silly hex-encoding protocol within the sillad framework"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+hex = "0.4.3"
+async-trait = "0.1.80"
+pin-project = "1.1.5"
+futures-util = { version = "0.3.30", features = ["io"] }
+sillad = { version = "0.2", path = "../sillad" }

--- a/libraries/sillad-hex/src/lib.rs
+++ b/libraries/sillad-hex/src/lib.rs
@@ -1,0 +1,98 @@
+use std::pin::Pin;
+use futures_util::{AsyncRead, AsyncWrite};
+use pin_project::pin_project;
+use std::task::{Context, Poll};
+use async_trait::async_trait;
+use sillad::{dialer::Dialer, listener::Listener, Pipe};
+
+#[pin_project]
+pub struct HexPipe<P: Pipe> {
+    #[pin]
+    inner: P,
+    read_buf: Vec<u8>,
+    leftover: Vec<u8>,
+}
+
+impl<P: Pipe> HexPipe<P> {
+    pub fn new(inner: P) -> Self {
+        Self { inner, read_buf: Vec::new(), leftover: Vec::new() }
+    }
+}
+
+impl<P: Pipe> AsyncRead for HexPipe<P> {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
+        let mut this = self.project();
+        if !this.read_buf.is_empty() {
+            let n = buf.len().min(this.read_buf.len());
+            buf[..n].copy_from_slice(&this.read_buf[..n]);
+            this.read_buf.drain(..n);
+            return Poll::Ready(Ok(n));
+        }
+        let mut tmp = [0u8; 4096];
+        match Pin::new(&mut this.inner).poll_read(cx, &mut tmp) {
+            Poll::Ready(Ok(0)) => {
+                if this.leftover.is_empty() {
+                    Poll::Ready(Ok(0))
+                } else {
+                    Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "incomplete hex")))
+                }
+            }
+            Poll::Ready(Ok(n)) => {
+                this.leftover.extend_from_slice(&tmp[..n]);
+                let decode_len = this.leftover.len() / 2 * 2;
+                let decoded = match hex::decode(&this.leftover[..decode_len]) {
+                    Ok(v) => v,
+                    Err(_) => return Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad hex"))),
+                };
+                this.read_buf.extend_from_slice(&decoded);
+                this.leftover.drain(..decode_len);
+                let n = buf.len().min(this.read_buf.len());
+                buf[..n].copy_from_slice(&this.read_buf[..n]);
+                this.read_buf.drain(..n);
+                Poll::Ready(Ok(n))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<P: Pipe> AsyncWrite for HexPipe<P> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
+        let mut this = self.project();
+        let encoded = hex::encode(buf);
+        this.inner.as_mut().poll_write(cx, encoded.as_bytes()).map_ok(|_| buf.len())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+        this.inner.as_mut().poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+        this.inner.as_mut().poll_close(cx)
+    }
+}
+
+impl<P: Pipe> Pipe for HexPipe<P> {
+    fn shared_secret(&self) -> Option<&[u8]> { self.inner.shared_secret() }
+    fn protocol(&self) -> &str { "hex" }
+    fn remote_addr(&self) -> Option<&str> { self.inner.remote_addr() }
+}
+
+pub struct HexDialer<D: Dialer> { pub inner: D }
+
+#[async_trait]
+impl<D: Dialer> Dialer for HexDialer<D> {
+    type P = HexPipe<D::P>;
+    async fn dial(&self) -> std::io::Result<Self::P> { self.inner.dial().await.map(HexPipe::new) }
+}
+
+pub struct HexListener<L: Listener> { pub inner: L }
+
+#[async_trait]
+impl<L: Listener> Listener for HexListener<L> {
+    type P = HexPipe<L::P>;
+    async fn accept(&mut self) -> std::io::Result<Self::P> { self.inner.accept().await.map(HexPipe::new) }
+}


### PR DESCRIPTION
## Summary
- add `sillad-hex` implementing simple hex encoding
- include new `Hex` variant in `ObfsProtocol` and `RouteDescriptor`
- support hex layer in broker, exit, client and prototest

## Testing
- `cargo check -p sillad-hex`
- `cargo check -p geph5-prototest`
- `cargo check -p geph5-client`
- `cargo check -p geph5-exit`
- `cargo check -p geph5-broker`


------
https://chatgpt.com/codex/tasks/task_b_685084d1c19c83338f35b12b29d9c850