### PR TITLE
refactor hex transport

### DIFF
--- a/libraries/sillad-hex/Cargo.toml
+++ b/libraries/sillad-hex/Cargo.toml
@@ -12,3 +12,6 @@ async-trait = "0.1.80"
 pin-project = "1.1.5"
 futures-util = { version = "0.3.30", features = ["io"] }
 sillad = { version = "0.2", path = "../sillad" }
+bipe = "0.2.8"
+smolscale = "0.4.16"
+async-task = "4.7.1"

--- a/libraries/sillad-hex/src/lib.rs
+++ b/libraries/sillad-hex/src/lib.rs
@@ -1,91 +1,117 @@
 use std::pin::Pin;
-use futures_util::{AsyncRead, AsyncWrite};
-use pin_project::pin_project;
-use std::task::{Context, Poll};
+
+use async_task::Task;
 use async_trait::async_trait;
+use futures_util::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use pin_project::pin_project;
 use sillad::{dialer::Dialer, listener::Listener, Pipe};
 
+use bipe::{BipeReader, BipeWriter};
+
 #[pin_project]
-pub struct HexPipe<P: Pipe> {
+pub struct HexPipe {
     #[pin]
-    inner: P,
-    read_buf: Vec<u8>,
-    leftover: Vec<u8>,
+    read_incoming: BipeReader,
+    _read_task: Task<()>,
+    #[pin]
+    write_outgoing: BipeWriter,
+    _write_task: Task<()>,
+    addr: Option<String>,
 }
 
-impl<P: Pipe> HexPipe<P> {
-    pub fn new(inner: P) -> Self {
-        Self { inner, read_buf: Vec::new(), leftover: Vec::new() }
-    }
-}
+impl HexPipe {
+    pub fn new<P: Pipe>(pipe: P) -> Self {
+        let addr = pipe.remote_addr().map(|s| s.to_string());
+        let (mut read_half, mut write_half) = pipe.split();
+        let (mut write_incoming, read_incoming) = bipe::bipe(32768);
+        let (write_outgoing, mut read_outgoing) = bipe::bipe(32768);
 
-impl<P: Pipe> AsyncRead for HexPipe<P> {
-    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
-        let mut this = self.project();
-        if !this.read_buf.is_empty() {
-            let n = buf.len().min(this.read_buf.len());
-            buf[..n].copy_from_slice(&this.read_buf[..n]);
-            this.read_buf.drain(..n);
-            return Poll::Ready(Ok(n));
-        }
-        let mut tmp = [0u8; 4096];
-        match Pin::new(&mut this.inner).poll_read(cx, &mut tmp) {
-            Poll::Ready(Ok(0)) => {
-                if this.leftover.is_empty() {
-                    Poll::Ready(Ok(0))
-                } else {
-                    Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "incomplete hex")))
+        let _read_task = smolscale::spawn(async move {
+            let mut leftover = Vec::new();
+            let mut buf = [0u8; 8192];
+            loop {
+                match read_half.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        leftover.extend_from_slice(&buf[..n]);
+                        let decode_len = leftover.len() / 2 * 2;
+                        if decode_len == 0 {
+                            continue;
+                        }
+                        match hex::decode(&leftover[..decode_len]) {
+                            Ok(decoded) => {
+                                if write_incoming.write_all(&decoded).await.is_err() {
+                                    break;
+                                }
+                                leftover.drain(..decode_len);
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    Err(_) => break,
                 }
             }
-            Poll::Ready(Ok(n)) => {
-                this.leftover.extend_from_slice(&tmp[..n]);
-                let decode_len = this.leftover.len() / 2 * 2;
-                let decoded = match hex::decode(&this.leftover[..decode_len]) {
-                    Ok(v) => v,
-                    Err(_) => return Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad hex"))),
-                };
-                this.read_buf.extend_from_slice(&decoded);
-                this.leftover.drain(..decode_len);
-                let n = buf.len().min(this.read_buf.len());
-                buf[..n].copy_from_slice(&this.read_buf[..n]);
-                this.read_buf.drain(..n);
-                Poll::Ready(Ok(n))
+        });
+
+        let _write_task = smolscale::spawn(async move {
+            let mut buf = [0u8; 8192];
+            loop {
+                match read_outgoing.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let encoded = hex::encode(&buf[..n]);
+                        if write_half.write_all(encoded.as_bytes()).await.is_err() {
+                            break;
+                        }
+                        if write_half.flush().await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
             }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Pending => Poll::Pending,
+        });
+
+        Self {
+            read_incoming,
+            _read_task,
+            write_outgoing,
+            _write_task,
+            addr,
         }
     }
 }
 
-impl<P: Pipe> AsyncWrite for HexPipe<P> {
-    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
-        let mut this = self.project();
-        let encoded = hex::encode(buf);
-        this.inner.as_mut().poll_write(cx, encoded.as_bytes()).map_ok(|_| buf.len())
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let mut this = self.project();
-        this.inner.as_mut().poll_flush(cx)
-    }
-
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let mut this = self.project();
-        this.inner.as_mut().poll_close(cx)
+impl AsyncRead for HexPipe {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>, buf: &mut [u8]) -> std::task::Poll<std::io::Result<usize>> {
+        self.project().read_incoming.poll_read(cx, buf)
     }
 }
 
-impl<P: Pipe> Pipe for HexPipe<P> {
-    fn shared_secret(&self) -> Option<&[u8]> { self.inner.shared_secret() }
+impl AsyncWrite for HexPipe {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>, buf: &[u8]) -> std::task::Poll<std::io::Result<usize>> {
+        self.project().write_outgoing.poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<std::io::Result<()>> {
+        self.project().write_outgoing.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<std::io::Result<()>> {
+        self.project().write_outgoing.poll_close(cx)
+    }
+}
+
+impl Pipe for HexPipe {
     fn protocol(&self) -> &str { "hex" }
-    fn remote_addr(&self) -> Option<&str> { self.inner.remote_addr() }
+    fn remote_addr(&self) -> Option<&str> { self.addr.as_deref() }
 }
 
 pub struct HexDialer<D: Dialer> { pub inner: D }
 
 #[async_trait]
 impl<D: Dialer> Dialer for HexDialer<D> {
-    type P = HexPipe<D::P>;
+    type P = HexPipe;
     async fn dial(&self) -> std::io::Result<Self::P> { self.inner.dial().await.map(HexPipe::new) }
 }
 
@@ -93,6 +119,7 @@ pub struct HexListener<L: Listener> { pub inner: L }
 
 #[async_trait]
 impl<L: Listener> Listener for HexListener<L> {
-    type P = HexPipe<L::P>;
+    type P = HexPipe;
     async fn accept(&mut self) -> std::io::Result<Self::P> { self.inner.accept().await.map(HexPipe::new) }
 }
+


### PR DESCRIPTION
## Summary
- refactor `sillad-hex` transport to use bipe-based background tasks
- add `bipe`, `smolscale` and `async-task` dependencies

## Testing
- `cargo check -p sillad-hex` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ea5555db88333a29c85018d6ce578