### PR TITLE
geph5-client: use jemalloc as global allocator

### DIFF
--- a/binaries/geph5-client/Cargo.toml
+++ b/binaries/geph5-client/Cargo.toml
@@ -119,6 +119,9 @@ rlimit = "0.10.2"
 async-channel = "2.5.0"
 native-tls = "0.2"
 tracing-oslog = "0.3.0"
+tikv-jemallocator = { version = "0.6.1", features = [
+  "unprefixed_malloc_on_supported_platforms",
+] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Networking_WinSock"] }

--- a/binaries/geph5-client/src/bin/geph5-client.rs
+++ b/binaries/geph5-client/src/bin/geph5-client.rs
@@ -8,6 +8,9 @@ use bytes::Bytes;
 use clap::Parser;
 use geph5_client::{Client, Config};
 
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// Run the Geph5 client.
 #[derive(Parser)]
 struct CliArgs {


### PR DESCRIPTION
geph5-client was the only binary missing jemalloc (exit, bridge, and
broker all set it as #[global_allocator]). On tokio multi-threaded
workloads with high-frequency small allocations in the picomux data
path, the default glibc allocator fragments heavily and never returns
memory to the OS, causing steady RSS growth.

This aligns geph5-client with the other binaries.
Related to #145 